### PR TITLE
Spotify account linking: integration fixes

### DIFF
--- a/Django/Meetify/urls.py
+++ b/Django/Meetify/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path('user/refresh-token', views.user_refresh_token),
     path('user/<int:user_id>/profile', views.user_profile),
     path('user/callback', views.user_callback),
+    path('user/is-linked', views.user_is_linked),
     path('user/update-liked-songs', views.user_update_liked_songs),
     path('user/update-top-artists', views.user_update_user_top_artists),
     path('user/update-top-tracks', views.user_update_user_top_tracks),

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -116,7 +116,7 @@ def user_profile(request, user_id):
 @csrf_exempt
 def user_callback(request):
     auth = spotipy.oauth2.SpotifyOAuth(client_id=os.getenv('SPOTIPY_CLIENT_ID'), client_secret=os.getenv('SPOTIPY_CLIENT_SECRET'), redirect_uri="http://localhost:8000/user/callback")
-    token = auth.get_access_token(code=request.GET.get('code'))
+    token = auth.get_access_token(code=request.GET.get('code'), check_cache=False)
     user_info = User_Info.objects.get(pk=request.GET.get('state'))
 
     sp = spotipy.Spotify(token['access_token'])

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -134,10 +134,9 @@ def user_callback(request):
 def user_is_linked(request):
     if request.method == 'GET':
         user_info = User_Info.objects.get(pk=request.user.pk)
-        if user_info.SpotifyUserId:
-            return HttpResponse(True)
-    
-        return HttpResponse(False)
+        
+        is_linked = user_info.SpotifyUserId is not None
+        return JsonResponse({'IsLinked': is_linked})
 
     return HttpResponse(status=405, reason="Invalid request method")
 

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -131,6 +131,18 @@ def user_callback(request):
 
 
 @csrf_exempt
+def user_is_linked(request):
+    if request.method == 'GET':
+        user_info = User_Info.objects.get(pk=request.user.pk)
+        if user_info.SpotifyUserId:
+            return HttpResponse(True)
+    
+        return HttpResponse(False)
+
+    return HttpResponse(status=405, reason="Invalid request method")
+
+
+@csrf_exempt
 def user_update_liked_songs(request):
     users.update_liked_songs(request)
     return HttpResponse()

--- a/docs/api_docs/user.md
+++ b/docs/api_docs/user.md
@@ -67,6 +67,17 @@
 - Status Codes:
     - `200` - Successfully linked Spotify account
 
+#### `GET user/is-linked`
+- Returns a boolean indicating whether the user is linked to a Spotify account
+- Status Codes:
+    - `200` - Successfully returned boolean
+- Sample response body:
+```
+{
+    "IsLinked": false
+}
+```
+
 #### `GET user/refresh-token`
 - Refreshes the Spotify API token for the Meetify user that is currently logged in
 - Status Codes:


### PR DESCRIPTION
Minor tweaks to the `/user/link-account` endpoint as well as a new endpoint, `/user/is-linked`, for determining if a user already has a Spotify account linked.

The code changes made here are required for the following PR for the front-end:

https://github.com/segeeslice/Meetify-UI/pull/19