### PR TITLE
Encode message strings with explicit escape characters

### DIFF
--- a/Django/Meetify/serializers.py
+++ b/Django/Meetify/serializers.py
@@ -52,9 +52,14 @@ class MatchesSerializerMatchedWith(serializers.ModelSerializer):
 
 
 class MessagesSerializer(serializers.ModelSerializer):
+    Text = serializers.SerializerMethodField()
+
     class Meta:
         model = Messages
         fields = '__all__'
+
+    def get_Text(self, obj):
+        return obj.Text.encode('unicode_escape').decode('utf-8')
 
 
 class LikedSongsSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
The messages serializer has been modified to encode string escape characters, which allows us to properly pass line breaks in the JSON response.

Obtained the solution from [this StackOverflow post](https://stackoverflow.com/a/15392758) after some discussion with @segeeslice .

Resolves #47 .

This will require some further integration work in the front-end since the messages are being displayed with the explicit `\n`, but I believe that this is the best solution from the back-end perspective. @segeeslice If this is for some reason not possible to work with, let me know and I'll come up with something else.

Screenshot of messages with line breaks:

![image](https://user-images.githubusercontent.com/54593008/109908827-f72d7700-7c72-11eb-8238-583c87732d84.png)
