### PR TITLE
Update profile pic with Spotify profile pic

### DIFF
--- a/Django/Meetify/appapi/users.py
+++ b/Django/Meetify/appapi/users.py
@@ -238,3 +238,9 @@ def get_feature_differences(user1, user2):
             "valence": abs(user1_scores.valence - user2_scores.valence)
         }
     return dict
+
+def update_profile_pic(request):
+    sp = spotipy.Spotify(request.session['sp_token']['access_token'])
+    user = User_Info.objects.get(pk=request.user.pk)
+    user.ProfilePicURL = sp.user(user.SpotifyUserId)['images'][0]['url']
+    user.save(update_fields=['ProfilePicURL'])

--- a/Django/Meetify/urls.py
+++ b/Django/Meetify/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('user/update-top-tracks', views.user_update_user_top_tracks),
     path('user/update-audio-features-scores', views.user_update_user_audio_features_scores),
     path('user/update-matches', views.user_update_matches),
+    path('user/update-profile-pic', views.user_update_profile_pic),
     path('user/update-all', views.user_update_all),
 
     # MATCHING

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -197,11 +197,17 @@ def user_update_profile_pic(request):
 
 @csrf_exempt
 def user_update_all(request):
-    users.update_liked_songs(request)
-    users.update_user_audio_features_scores(request)
-    users.update_profile_pic(request)
-    return HttpResponse()
+    if request.method == 'GET':
+        if User_Info.objects.get(request.user.pk).SpotifyUserId:
+            users.update_liked_songs(request)
+            users.update_user_audio_features_scores(request)
+            users.update_profile_pic(request)
+            return HttpResponse()
+        else:
+            return HttpResponse(status=401, reason="User has no linked Spotify account")
 
+    return HttpResponse(status=405, reason="Invalid request method")
+    
 @csrf_exempt
 def matching_accept_match(request):
     result=matching.accept_match(request)

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -192,8 +192,14 @@ def user_update_matches(request):
     return HttpResponse()
 
 def user_update_profile_pic(request):
-    users.update_profile_pic(request)
-    return HttpResponse()
+    if request.method == 'GET':
+        if User_Info.objects.get(request.user.pk).SpotifyUserId:
+            users.update_profile_pic(request)
+            return HttpResponse()
+        else:
+            return HttpResponse(status=401, reason="User has no linked Spotify account")
+
+    return HttpResponse(status=405, reason="Invalid request method")
 
 @csrf_exempt
 def user_update_all(request):

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -191,10 +191,15 @@ def user_update_matches(request):
     users.update_user_matches(request)
     return HttpResponse()
 
+def user_update_profile_pic(request):
+    users.update_profile_pic(request)
+    return HttpResponse()
+
 @csrf_exempt
 def user_update_all(request):
     users.update_liked_songs(request)
     users.update_user_audio_features_scores(request)
+    users.update_profile_pic(request)
     return HttpResponse()
 
 @csrf_exempt

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -193,7 +193,7 @@ def user_update_matches(request):
 
 def user_update_profile_pic(request):
     if request.method == 'GET':
-        if User_Info.objects.get(request.user.pk).SpotifyUserId:
+        if User_Info.objects.get(pk=request.user.pk).SpotifyUserId:
             users.update_profile_pic(request)
             return HttpResponse()
         else:
@@ -204,7 +204,7 @@ def user_update_profile_pic(request):
 @csrf_exempt
 def user_update_all(request):
     if request.method == 'GET':
-        if User_Info.objects.get(request.user.pk).SpotifyUserId:
+        if User_Info.objects.get(pk=request.user.pk).SpotifyUserId:
             users.update_liked_songs(request)
             users.update_user_audio_features_scores(request)
             users.update_profile_pic(request)

--- a/docs/api_docs/user.md
+++ b/docs/api_docs/user.md
@@ -78,6 +78,18 @@
 }
 ```
 
+#### `GET` user/update-profile-pic
+- Syncs the profile pic of the current user with their Spotify profile pic
+- Status Codes:
+    - `200` - Successfully updated profile pic
+    - `401` - User has no linked Spotify account
+
+#### `GET` user/update-all
+- Pulls Spotify data to update database with current data
+- Status Codes:
+    - `200` - Successfully updated Spotify data
+    - `401` - User has no linked Spotify account
+
 #### `GET user/refresh-token`
 - Refreshes the Spotify API token for the Meetify user that is currently logged in
 - Status Codes:


### PR DESCRIPTION
Calling the `/user/update-profile-pic` endpoint will sync the Meetify user's profile pic with their Spotify profile pic. This also happens in `user/update-all`.

Also added some additional checks for if the account is linked and updated documentation.

Resolves #35 
Resolves #30 