### PR TITLE
Add scheduled update job and fix endpoint slowness

### DIFF
--- a/Django/Meetify/__init__.py
+++ b/Django/Meetify/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from .celery import app as celery_app
+
 import pymysql
 # pymysql.version_info = (1, 4, 0, "final", 0)
 # pymysql.install_as_MySQLdb()

--- a/Django/Meetify/celery.py
+++ b/Django/Meetify/celery.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+import os
+from celery import Celery
+from django.conf import settings
+
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Meetify.settings')
+app = Celery('Meetify')
+
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/Django/Meetify/settings.py
+++ b/Django/Meetify/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_extensions',
     'corsheaders',
+    'django_celery_beat',
     'Meetify.apps.MeetifyConfig'
 ]
 
@@ -152,3 +153,10 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 AUTHENTICATION_BACKENDS = ('Meetify.authentication.EmailBackend',)
+
+# Celery
+BROKER_URL = 'amqp://localhost'
+CELERY_ACCEPT_CONTENT = ['application/json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_IMPORTS = ('Meetify.tasks.tasks')

--- a/Django/Meetify/tasks/tasks.py
+++ b/Django/Meetify/tasks/tasks.py
@@ -1,0 +1,10 @@
+from celery.schedules import crontab
+from ..celery import app
+from .updates import *
+
+
+@app.on_after_finalize.connect
+def setup_periodic_tasks(sender, **kwargs):
+    # Update user data (Daily @ 6:00AM UTC / 1:00AM EST)
+    sender.add_periodic_task(crontab(hour=6), update_user_data.s(), name='Update user data')
+

--- a/Django/Meetify/tasks/updates.py
+++ b/Django/Meetify/tasks/updates.py
@@ -1,0 +1,13 @@
+from ..celery import app
+from ..models import User_Info
+from ..appapi import users as u
+
+
+@app.task
+def update_user_data():
+    users = User_Info.objects.filter(SpotifyUserId__isnull=False)
+    for user in users:
+        token = u.refresh_token(user.SpotifyAuthToken)
+        u.update_liked_songs(user.pk, token)
+        u.update_user_audio_features_scores(user.pk, token)
+        u.update_user_matches(user.pk, token)

--- a/Django/Meetify/views.py
+++ b/Django/Meetify/views.py
@@ -145,7 +145,7 @@ def user_is_linked(request):
     return HttpResponse(status=405, reason="Invalid request method")
 
 def user_update_liked_songs(request):
-    users.update_liked_songs(request)
+    users.update_liked_songs_request(request)
     return HttpResponse()
 
 def user_update_user_top_artists(request):
@@ -157,7 +157,7 @@ def user_update_user_top_tracks(request):
     return HttpResponse()
     
 def user_update_user_audio_features_scores(request):
-    users.update_user_audio_features_scores(request)
+    users.update_user_audio_features_scores_request(request)
     return HttpResponse()
 
 def matching_intersect_userid_liked_songs(request):
@@ -188,7 +188,7 @@ def matching_accepted_matches(request):
     return HttpResponse(status=405, reason="Invalid request method")
 
 def user_update_matches(request):
-    users.update_user_matches(request)
+    users.update_user_matches_request(request)
     return HttpResponse()
 
 def user_update_profile_pic(request):
@@ -205,8 +205,9 @@ def user_update_profile_pic(request):
 def user_update_all(request):
     if request.method == 'GET':
         if User_Info.objects.get(pk=request.user.pk).SpotifyUserId:
-            users.update_liked_songs(request)
-            users.update_user_audio_features_scores(request)
+            users.update_liked_songs_request(request)
+            users.update_user_audio_features_scores_request(request)
+            users.update_user_matches_request(request)
             users.update_profile_pic(request)
             return HttpResponse()
         else:

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ To accomplish these goals, **Meetify** utilizes the following technologies:
 
 ## Dependencies
 
-- `pip install mysql mysql-connector spotipy pillow django-extensions djangorestframework django-cors-headers pymysql`
+- `pip install mysql mysql-connector spotipy pillow django-extensions djangorestframework django-cors-headers pymysql celery django_celery_beat`

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -1,0 +1,30 @@
+# Automated Tasks
+
+## Setup
+
+### Rabbitmq
+- Acts as a broker for automated tasks
+- Needs to be running on same machine as tasks
+- Can be run on docker:
+```
+docker run -d -p 5672:5672 rabbitmq
+```
+
+### Celery Worker
+- Performs the tasks
+- Tasks are functions with the `@app.task` decorator and should be located in the `Django/Meetify/tasks` directory
+- Start the worker using:
+```
+celery -A Meetify worker
+```
+
+### Celery Beat
+- Schedules the tasks
+- Periodic tasks are stored in database table named `django_celery_beat_periodictask`
+- Add periodic task by adding it to the `setup_periodic_tasks` function in `tasks.py`
+- Delete tasks by removing them from the `django_celery_beat_periodictask` table
+- *Both celery beat and celery worker need to be running for scheduled tasks to work*
+- Start beat using:
+```
+celery -A Meetify beat --scheduler django_celery_beat.schedulers:DatabaseScheduler
+```

--- a/docs/automation/updates.md
+++ b/docs/automation/updates.md
@@ -1,0 +1,11 @@
+# Update Tasks
+
+## Used for updating database information
+
+### Update user data
+- Function name: `update_user_data()`
+- Use: updates the following information for each user with a linked Spotify account
+    - Liked songs
+    - Audio features scores
+    - Matches
+- Schedule: Every day @ 6:00AM UTC (1:00AM EST)


### PR DESCRIPTION
- Added a scheduled Celery task using Celery Beat
- Fixed slowness issues in liked songs update
- Refactored users.py to accommodate new task

Check out the newly-added tasks documentation for some information on getting celery set up. Once this is merged we should go ahead and get the task scheduler set up on the remote server so we won't have to worry about manually updating data as much.

Resolves #49 